### PR TITLE
NotificationSettings map memory allocation bugfix for the missing case.

### DIFF
--- a/users/internal/device/settings/settings.go
+++ b/users/internal/device/settings/settings.go
@@ -58,6 +58,7 @@ func (ds *DeviceSettings) addMissingNewNotificationSettings() *DeviceSettings {
 	}
 	if ds.NotificationSettings == nil {
 		ds.NotificationSettings = new(NotificationSettings)
+		*ds.NotificationSettings = make(NotificationSettings, len(AllNotificationDomains))
 	}
 	for k, v := range *defaultNotificationSettings() {
 		if _, alreadyPresent := (*ds.NotificationSettings)[k]; !alreadyPresent {


### PR DESCRIPTION
NotificationSettings map memory allocation bugfix for the missing case.