### PR TITLE
fix issue when newly created users cannot be pinged, 0/null value is …

### DIFF
--- a/users/users_get.go
+++ b/users/users_get.go
@@ -113,7 +113,7 @@ func (r *repository) GetUsers(ctx context.Context, arg *GetUsersArg) (result []*
 			SELECT u.last_mining_started_at                                                                          AS last_mining_started_at,
 				   (CASE
 						WHEN t0.id = :userId
-							THEN u.last_ping_at
+							THEN COALESCE(NULLIF(COALESCE(u.last_ping_at,0),0), :nowNanos)
 						ELSE :nowNanos
 					END)                                                                                             AS last_ping_at,	
 				   u.id                                                                                              AS id,

--- a/users/users_referrals.go
+++ b/users/users_referrals.go
@@ -77,7 +77,7 @@ func (r *repository) GetReferrals(ctx context.Context, arg *GetReferralsArg) (*R
 				referrals.last_mining_started_at                                                       AS last_mining_started_at,
 				(CASE
 					WHEN u.id = referrals.referred_by
-						THEN referrals.last_ping_at
+						THEN COALESCE(NULLIF(COALESCE(referrals.last_ping_at,0),0), :nowNanos)
 					ELSE :nowNanos
 				 END)                                                                                  AS last_ping_at,
 				referrals.ID                                                                           AS id,


### PR DESCRIPTION
It seems there are some issues with pingAllowed field with default data / scenario.
When user created it has last_ping_at == 0 by default, so when t0.id == currentUserId (user is referred by current), 0 is interpreted as false in bool cast (cuz of expired zero value) and ping option is never become available.