### PR TITLE
Modify email custom auth error handling fix

### DIFF
--- a/auth/email_link/contract.go
+++ b/auth/email_link/contract.go
@@ -50,6 +50,7 @@ var (
 
 	ErrUserDataMismatch = errors.New("parameters were not equal to user data in db")
 	ErrUserNotFound     = storage.ErrNotFound
+	ErrUserDuplicate    = errors.New("such user already exists")
 
 	ErrConfirmationCodeWrong            = errors.New("wrong confirmation code provided")
 	ErrConfirmationCodeAttemptsExceeded = errors.New("confirmation code attempts exceeded")

--- a/auth/email_link/users.go
+++ b/auth/email_link/users.go
@@ -62,6 +62,18 @@ func (c *client) getUserIDFromEmail(ctx context.Context, searchEmail, idIfNotFou
 	return ids[0].ID, nil
 }
 
+func (c *client) isUserExist(ctx context.Context, email string) error {
+	type dbUser struct {
+		ID string
+	}
+	sql := `SELECT id 
+				FROM users 
+					WHERE email = $1`
+	_, err := storage.Get[dbUser](ctx, c.db, sql, email)
+
+	return errors.Wrapf(err, "failed to find user by email:%v", email)
+}
+
 //nolint:funlen // .
 func (c *client) getUserByIDOrPk(ctx context.Context, userID string, id *loginID) (*emailLinkSignIn, error) {
 	if ctx.Err() != nil {

--- a/cmd/eskimo-hut/api/docs.go
+++ b/cmd/eskimo-hut/api/docs.go
@@ -189,6 +189,12 @@ const docTemplate = `{
                             "$ref": "#/definitions/main.Auth"
                         }
                     },
+                    "409": {
+                        "description": "if email conflicts with another user's",
+                        "schema": {
+                            "$ref": "#/definitions/server.ErrorResponse"
+                        }
+                    },
                     "422": {
                         "description": "if syntax fails",
                         "schema": {
@@ -606,7 +612,7 @@ const docTemplate = `{
                         }
                     },
                     "409": {
-                        "description": "if username, email or phoneNumber conflict with another other user's",
+                        "description": "if username, email or phoneNumber conflict with another user's",
                         "schema": {
                             "$ref": "#/definitions/server.ErrorResponse"
                         }

--- a/cmd/eskimo-hut/api/swagger.json
+++ b/cmd/eskimo-hut/api/swagger.json
@@ -184,6 +184,12 @@
                             "$ref": "#/definitions/main.Auth"
                         }
                     },
+                    "409": {
+                        "description": "if email conflicts with another user's",
+                        "schema": {
+                            "$ref": "#/definitions/server.ErrorResponse"
+                        }
+                    },
                     "422": {
                         "description": "if syntax fails",
                         "schema": {
@@ -601,7 +607,7 @@
                         }
                     },
                     "409": {
-                        "description": "if username, email or phoneNumber conflict with another other user's",
+                        "description": "if username, email or phoneNumber conflict with another user's",
                         "schema": {
                             "$ref": "#/definitions/server.ErrorResponse"
                         }

--- a/cmd/eskimo-hut/api/swagger.yaml
+++ b/cmd/eskimo-hut/api/swagger.yaml
@@ -438,6 +438,10 @@ paths:
           description: OK
           schema:
             $ref: '#/definitions/main.Auth'
+        "409":
+          description: if email conflicts with another user's
+          schema:
+            $ref: '#/definitions/server.ErrorResponse'
         "422":
           description: if syntax fails
           schema:
@@ -717,8 +721,7 @@ paths:
           schema:
             $ref: '#/definitions/server.ErrorResponse'
         "409":
-          description: if username, email or phoneNumber conflict with another other
-            user's
+          description: if username, email or phoneNumber conflict with another user's
           schema:
             $ref: '#/definitions/server.ErrorResponse'
         "422":

--- a/cmd/eskimo-hut/users.go
+++ b/cmd/eskimo-hut/users.go
@@ -109,7 +109,7 @@ func buildUserForCreation(req *server.Request[CreateUserRequestBody, User]) *use
 //	@Failure		401					{object}	server.ErrorResponse	"if not authorized"
 //	@Failure		403					{object}	server.ErrorResponse	"not allowed"
 //	@Failure		404					{object}	server.ErrorResponse	"user is not found; or the referred by is not found"
-//	@Failure		409					{object}	server.ErrorResponse	"if username, email or phoneNumber conflict with another other user's"
+//	@Failure		409					{object}	server.ErrorResponse	"if username, email or phoneNumber conflict with another user's"
 //	@Failure		422					{object}	server.ErrorResponse	"if syntax fails"
 //	@Failure		500					{object}	server.ErrorResponse
 //	@Failure		504					{object}	server.ErrorResponse	"if request times out"
@@ -130,6 +130,8 @@ func (s *service) ModifyUser( //nolint:gocritic,funlen // .
 			return nil, server.NotFound(errors.Wrapf(err, "user with id `%v` was not found", req.AuthenticatedUser.UserID), userNotFoundErrorCode)
 		case errors.Is(err, emaillink.ErrUserBlocked):
 			return nil, server.BadRequest(err, userBlockedErrorCode)
+		case errors.Is(err, emaillink.ErrUserDuplicate):
+			return nil, server.Conflict(err, duplicateUserErrorCode)
 		default:
 			return nil, server.Unexpected(errors.Wrapf(err, "failed to trigger email modification for request:%#v", req.Data))
 		}


### PR DESCRIPTION
New email already exists check for email modification before sending magic link. SignIn on ModifyUser case errors handling. SendSignInLinkToEmail function was splitted into several functions to pass linters without nolint usage.