### PR TITLE
referrals history fixes

### DIFF
--- a/users/users_referrals.go
+++ b/users/users_referrals.go
@@ -332,14 +332,16 @@ func (r *repository) incrementOrDecrementReferralCount(ctx context.Context, user
 			t1_today = (CASE
 				WHEN referral_acquisition_history.user_id = $1 and referral_acquisition_history.date = $5 THEN GREATEST(referral_acquisition_history.t1_today %[4]v 1,0)
 				WHEN referral_acquisition_history.user_id = $1 and referral_acquisition_history.date != $5 THEN GREATEST(0 %[4]v 1, 0)
-				ELSE referral_acquisition_history.t1_today END),
+				WHEN referral_acquisition_history.date = $5 THEN referral_acquisition_history.t1_today 
+			    ELSE 0 END),
 			t1 = (CASE
 				WHEN referral_acquisition_history.user_id = $1 THEN GREATEST(referral_acquisition_history.t1 %[3]v 1,0)
 				ELSE referral_acquisition_history.t1 END),
 			t2_today = (CASE
 			WHEN referral_acquisition_history.user_id = $6 AND referral_acquisition_history.date = $5 THEN GREATEST(referral_acquisition_history.t2_today %[4]v 1, 0)
 			WHEN referral_acquisition_history.user_id = $6 AND referral_acquisition_history.date != $5 THEN GREATEST(0 %[4]v 1, 0)
-			ELSE referral_acquisition_history.t2_today END),
+			WHEN referral_acquisition_history.date = $5 THEN referral_acquisition_history.t2_today
+		    ELSE 0 END),
 			t2 = (CASE
 			WHEN referral_acquisition_history.user_id = $6 THEN GREATEST(referral_acquisition_history.t2 %[3]v 1,0)
 			ELSE referral_acquisition_history.t2 END),


### PR DESCRIPTION
1) when user receives new T2 on some day, but no T1 the same day currently value from T1 is duplicated across the dates, for now it should reset to zero (and vice versa).

2) If one of (T0, T-1) stored date in referral_acquisition_history does not match current date (when T0 or T-1 receives new referral) date shift should occur on both, but it occured only for T0 date mismatch, so if T0 and T-1 had different dates, shift for T-1 could never occur.  