### PR TITLE
case insensitive user emails

### DIFF
--- a/auth/email_link/users.go
+++ b/auth/email_link/users.go
@@ -264,7 +264,7 @@ func (c *client) Metadata(ctx context.Context, userID, tokenEmail string) (strin
 	}
 	if md.Email != nil {
 		emailEmpty := *md.Email == "" || *md.Email == *md.UserID
-		if tokenEmail != "" && !emailEmpty && tokenEmail != *md.Email { //nolint:gosec // .
+		if tokenEmail != "" && !emailEmpty && !strings.EqualFold(tokenEmail, *md.Email) { //nolint:gosec // .
 			return "", nil, terror.New(ErrUserDataMismatch, map[string]any{"email": *md.Email})
 		}
 	}

--- a/cmd/eskimo-hut/auth.go
+++ b/cmd/eskimo-hut/auth.go
@@ -261,7 +261,7 @@ func (s *service) findMetadataUsingIceID(ctx context.Context, loggedInUser *serv
 ) {
 	var md string
 	var mdFields *users.JSON
-	iceID, iErr := s.authEmailLinkClient.IceUserID(ctx, loggedInUser.Email)
+	iceID, iErr := s.authEmailLinkClient.IceUserID(ctx, strings.ToLower(loggedInUser.Email))
 	if iErr != nil {
 		return nil, server.NotFound(multierror.Append(
 			errors.Wrapf(err, "metadata for user with id `%v` was not found", loggedInUser.UserID),

--- a/cmd/eskimo-hut/users.go
+++ b/cmd/eskimo-hut/users.go
@@ -91,7 +91,7 @@ func (s *service) CreateUser( //nolint:funlen,gocritic // .
 func buildUserForCreation(req *server.Request[CreateUserRequestBody, User]) *users.User {
 	usr := new(users.User)
 	usr.ID = req.AuthenticatedUser.UserID
-	usr.Email = req.Data.Email
+	usr.Email = strings.ToLower(req.Data.Email)
 	usr.PhoneNumber = req.Data.PhoneNumber
 	usr.PhoneNumberHash = req.Data.PhoneNumberHash
 	usr.FirstName = &req.Data.FirstName


### PR DESCRIPTION
For now create user endpoint can create user with user sensitive email, this PR fixes that and also handles the case if we'll get case-sensitive email from firebase token as we cannot control them.

SQL to convert existing users into lowercase:
```
UPDATE users SET email = lower(email) WHERE lower(email) != email AND email != id;
```
