### PR TITLE
Improved and simplified get TEAM referrals SQL: redone by JOIN usage instead of UNION

### DIFF
--- a/cmd/eskimo/api/docs.go
+++ b/cmd/eskimo/api/docs.go
@@ -574,7 +574,7 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
-                        "description": "Type of referrals: ` + "`" + `CONTACTS` + "`" + ` or ` + "`" + `T1` + "`" + ` or ` + "`" + `T2` + "`" + `",
+                        "description": "Type of referrals: ` + "`" + `CONTACTS` + "`" + ` or ` + "`" + `T1` + "`" + ` or ` + "`" + `T2` + "`" + ` or ` + "`" + `TEAM` + "`" + `",
                         "name": "type",
                         "in": "query",
                         "required": true

--- a/cmd/eskimo/api/swagger.json
+++ b/cmd/eskimo/api/swagger.json
@@ -568,7 +568,7 @@
                     },
                     {
                         "type": "string",
-                        "description": "Type of referrals: `CONTACTS` or `T1` or `T2`",
+                        "description": "Type of referrals: `CONTACTS` or `T1` or `T2` or `TEAM`",
                         "name": "type",
                         "in": "query",
                         "required": true

--- a/cmd/eskimo/api/swagger.yaml
+++ b/cmd/eskimo/api/swagger.yaml
@@ -711,7 +711,7 @@ paths:
         name: userId
         required: true
         type: string
-      - description: 'Type of referrals: `CONTACTS` or `T1` or `T2`'
+      - description: 'Type of referrals: `CONTACTS` or `T1` or `T2` or `TEAM`'
         in: query
         name: type
         required: true

--- a/cmd/eskimo/referrals.go
+++ b/cmd/eskimo/referrals.go
@@ -60,7 +60,7 @@ func (s *service) GetReferralAcquisitionHistory( //nolint:gocritic // False nega
 //	@Param			Authorization		header		string	true	"Insert your access token"		default(Bearer <Add access token here>)
 //	@Param			X-Account-Metadata	header		string	false	"Insert your metadata token"	default(<Add metadata token here>)
 //	@Param			userId				path		string	true	"ID of the user"
-//	@Param			type				query		string	true	"Type of referrals: `CONTACTS` or `T1` or `T2`"
+//	@Param			type				query		string	true	"Type of referrals: `CONTACTS` or `T1` or `T2` or `TEAM`"
 //	@Param			limit				query		uint64	false	"Limit of elements to return. Defaults to 10"
 //	@Param			offset				query		uint64	false	"Number of elements to skip before collecting elements to return"
 //	@Success		200					{object}	users.Referrals


### PR DESCRIPTION
Improved and simplified get TEAM referrals SQL: redone by JOIN usage instead of UNION.