### PR TITLE
fix issue with referral being reset during t0 deletion

### DIFF
--- a/users/DDL.sql
+++ b/users/DDL.sql
@@ -50,9 +50,7 @@ ALTER TABLE users ADD COLUMN IF NOT EXISTS kyc_step_blocked smallint NOT NULL DE
 ALTER TABLE users ADD COLUMN IF NOT EXISTS kyc_steps_last_updated_at timestamp[];
 ALTER TABLE users ADD COLUMN IF NOT EXISTS kyc_steps_created_at timestamp[];
 ALTER TABLE users ADD COLUMN IF NOT EXISTS telegram_user_id text;
-UPDATE users SET telegram_user_id = id WHERE telegram_user_id IS NULL;
 ALTER TABLE users ADD COLUMN IF NOT EXISTS telegram_bot_id text;
-UPDATE users SET telegram_bot_id = id WHERE telegram_bot_id IS NULL;
 ALTER TABLE users ALTER COLUMN telegram_bot_id SET NOT NULL;
 INSERT INTO users (created_at,updated_at,phone_number,phone_number_hash,email,id,username,profile_picture_name,referred_by,city,country,mining_blockchain_account_address,blockchain_account_address, telegram_user_id, telegram_bot_id, lookup)
                          VALUES (current_timestamp,current_timestamp,'bogus','bogus','bogus','bogus','bogus','bogus.jpg','bogus','bogus','RO','bogus','bogus','bogus','bogus',to_tsvector('bogus')),

--- a/users/users_delete.go
+++ b/users/users_delete.go
@@ -112,9 +112,13 @@ func (r *repository) updateReferredByForAllT1Referrals(ctx context.Context, user
 									SELECT r.id
 									FROM randomized r											
 									WHERE r.id != u.id
-										  AND r.referred_by != u.id
-										  AND r.created_at < u.created_at
-										  AND MOD(r.hash_code, (floor(random()*1000)+1)::bigint) = 0
+										AND r.referred_by != u.id
+										AND r.created_at < u.created_at
+										AND MOD(r.hash_code,(floor(random()*COALESCE(
+															(SELECT 
+																CASE WHEN (SELECT value FROM global WHERE key='TOTAL_USERS')>1000 THEN 1000
+																ELSE 5 
+															END),5))+1)::bigint)=0
 									LIMIT 1
 							) X
 		


### PR DESCRIPTION
issue occurs when all randomized users are filtered cuz MOD(r.hash_code, (floor(random()*1000)+1)::bigint)  == 0 is never triggered due to low total users count